### PR TITLE
Improve library build speed

### DIFF
--- a/classes/youtube.js
+++ b/classes/youtube.js
@@ -82,10 +82,11 @@ module.exports = {
 					filename
 				);
 
-				libraryService.addTrack(artist, title, genre);
-				wishesService.deleteWish(id);
+				libraryService.addTrack(artist, title, genre).then(() => {
+					wishesService.deleteWish(id);
 
-				callback();
+					callback();
+				});
 			});
 	}
 };

--- a/routes/dir.js
+++ b/routes/dir.js
@@ -18,8 +18,8 @@ router.put('/', (req, res) => {
 	}
 
 	const server = new WebSocket.Server({ port: 8080 });
-	server.on('connection', connection => {
-		libraryService.writeAllTracks(connection);
+	server.on('connection', async connection => {
+		await libraryService.writeAllTracks(connection);
 		if (req.body.dir) {
 			fs.appendFileSync('.env', '\nMUSIC_DIR=' + process.env.MUSIC_DIR);
 		}

--- a/routes/library.js
+++ b/routes/library.js
@@ -3,8 +3,8 @@ const router = express.Router();
 
 const libraryService = require('@/classes/library');
 
-router.put('/', (req, res) => {
-	const track = libraryService.update(req.body.url, req.body.artist, req.body.title, req.body.genre);
+router.put('/', async (req, res) => {
+	const track = await libraryService.update(req.body.url, req.body.artist, req.body.title, req.body.genre);
 
 	res.json({
 		success: true,


### PR DESCRIPTION
## Summary
- refactor library management to use asynchronous filesystem methods
- update directory route to await library generation
- make library update endpoint asynchronous
- wait for library writes when downloading a track

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6866de4769e48329ba3f6157427a07a6