### PR TITLE
Optimize library generation with async tag reading

### DIFF
--- a/routes/dir.js
+++ b/routes/dir.js
@@ -18,8 +18,8 @@ router.put('/', (req, res) => {
 	}
 
 	const server = new WebSocket.Server({ port: 8080 });
-	server.on('connection', connection => {
-		libraryService.writeAllTracks(connection);
+	server.on('connection', async connection => {
+		await libraryService.writeAllTracks(connection);
 		if (req.body.dir) {
 			fs.appendFileSync('.env', '\nMUSIC_DIR=' + process.env.MUSIC_DIR);
 		}


### PR DESCRIPTION
## Summary
- speed up track loading in `writeAllTracks` by reading tags concurrently
- await library generation before closing WebSocket connection

## Testing
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_686993135f448329a67170e2a9b5fe14