### PR TITLE
Use env for audio streaming

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,3 @@
 PORT=3000
 VITE_API=http://localhost:${PORT}/api
+VITE_AUDIO=http://localhost:${PORT}

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ npm install
 
 2. Assurez-vous que l'utilitaire `ffmpeg` est disponible sur votre machine.
 
-3. Définissez les variables d'environnement nécessaires dans un fichier `.env` (voir l'exemple fourni) : le port d'écoute (`PORT`) et le répertoire de musique (`MUSIC_DIR`).
+3. Définissez les variables d'environnement nécessaires dans un fichier `.env` (voir l'exemple fourni) : le port d'écoute (`PORT`), le répertoire de musique (`MUSIC_DIR`) ainsi que les URLs du serveur (`VITE_API` pour l'API et `VITE_AUDIO` pour la diffusion audio).
 
 ## Utilisation
 

--- a/front/components/MusicPlayer.vue
+++ b/front/components/MusicPlayer.vue
@@ -1,7 +1,7 @@
 <template>
 	<div v-if="app.currentTrack" class="fixed bottom-0 w-full text-start bg-white">
 		<text class="p-2">{{ app.currentTrack.artist }} - {{ app.currentTrack.title }}</text>
-		<audio ref="audio" class="w-full" :src="'http://localhost:3000' + app.currentTrack.url" controls autoplay @play="app.isPlaying = true" @pause="app.isPlaying = false" />
+		<audio ref="audio" class="w-full" :src="import.meta.env.VITE_AUDIO + app.currentTrack.url" controls autoplay @play="app.isPlaying = true" @pause="app.isPlaying = false" />
 	</div>
 </template>
 

--- a/front/components/TrackRow.vue
+++ b/front/components/TrackRow.vue
@@ -42,7 +42,7 @@ export default {
 	}),
 	async created() {
 		const audio = document.createElement('audio');
-		audio.src = 'http://localhost:3000' + this.track.url;
+		audio.src = import.meta.env.VITE_AUDIO + this.track.url;
 
 		while (isNaN(audio.duration)) {
 			await new Promise(r => setTimeout(r, 10));


### PR DESCRIPTION
## Summary
- read audio URL from `import.meta.env.VITE_AUDIO`
- document new `VITE_AUDIO` variable in README

## Testing
- `npm run format`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_686a2f0f8ff08329ac39c6dce0794d1c